### PR TITLE
remove `exclude_hess`

### DIFF
--- a/test/nls_testutils.jl
+++ b/test/nls_testutils.jl
@@ -9,7 +9,7 @@
   end
   @testset "Check dimensions" begin
     check_nls_dimensions(lls)
-    check_nlp_dimensions(lls, exclude_hess=true)
+    check_nlp_dimensions(lls, exclude=[hess, hess_coord])
   end
   @testset "Check view subarray" begin
     view_subarray_nls(lls)


### PR DESCRIPTION
`exclude_hess` has been removed in [NLPModelsTest 0.2.0 PR#5](https://github.com/JuliaSmoothOptimizers/NLPModelsTest.jl/pull/5) and replaced by `exclude`.

We move from 2149 tests to 2165 tests :).