### PR TITLE
exclude jth_hess, jth_hess_coord and jth_hprod

### DIFF
--- a/test/nls_testutils.jl
+++ b/test/nls_testutils.jl
@@ -17,7 +17,7 @@
   end
   @testset "Check dimensions" begin
     check_nls_dimensions(lls)
-    check_nlp_dimensions(lls, exclude = [hess, hess_coord])
+    check_nlp_dimensions(lls, exclude = [hess, hess_coord, jth_hess, jth_hess_coord, jth_hprod])
   end
   @testset "Multiple precision support" begin
     multiple_precision_nls(lls)


### PR DESCRIPTION
Add excluded functions in test.

Follow [PR 6 in NLPModelsTest.jl](https://github.com/JuliaSmoothOptimizers/NLPModelsTest.jl/pull/6)